### PR TITLE
Fix "Object argument required." error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-custom-domain",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Serverless plugin which creates a Custom Domain Name for the serverless service.",
   "main": "index.js",
   "scripts": {

--- a/services/domain-name-service.js
+++ b/services/domain-name-service.js
@@ -45,7 +45,7 @@ class DomainNameService extends ServerlessService {
 	}
 
 	async getDomainNameInfoAsync(domainName) {
-		const domains = await this.provider.request("APIGateway", "getDomainNames");
+		const domains = await this.provider.request("APIGateway", "getDomainNames", {});
 		if (!domains || !domains.items) {
 			return null;
 		}
@@ -63,7 +63,7 @@ class DomainNameService extends ServerlessService {
 		const region = "us-east-1";
 		this.options.region = region;
 
-		const certificates = await this.provider.request("ACM", "listCertificates");
+		const certificates = await this.provider.request("ACM", "listCertificates", {});
 		this.options.region = this._originalRegion;
 		if (!certificates || !certificates.CertificateSummaryList || !certificates.CertificateSummaryList.length) {
 			return null;

--- a/services/record-set-service.js
+++ b/services/record-set-service.js
@@ -98,7 +98,7 @@ class RecordSetService extends ServerlessService {
 	}
 
 	_getHostedZoneInfoAsync(hostedZoneName) {
-		return this.provider.request("Route53", "listHostedZones")
+		return this.provider.request("Route53", "listHostedZones", {})
 			.then(zones => {
 				if (!zones || !zones.HostedZones || !zones.HostedZones.length) {
 					return null;


### PR DESCRIPTION
There is a small breaking change in the serverless AWS provider api.
The `params` parameter in the request method is now required. This
happened after adding request cache -
https://github.com/serverless/serverless/pull/4518
The solution is to pass empty object to the request method when we try
to get the rest apis.