### PR TITLE
Fix Route53 assume role credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-custom-domain",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-custom-domain",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Serverless plugin which creates a Custom Domain Name for the serverless service.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The latest version of the serverless framework has cache for the AWS
credentials. Each request uses the cached credentials and we can't use
env vars to override the cached credentials. The solution is to create
new route53 service and use it instead of the providers request method