### PR TITLE
Fix the delete api mapping method

### DIFF
--- a/lib/services/base-path-mapping-service.js
+++ b/lib/services/base-path-mapping-service.js
@@ -99,12 +99,9 @@ class BasePathMappingService extends ServerlessService {
 	}
 
 	async _removeMappingAsync(domainName, basePath) {
-		const apiName = this.provider.naming.getApiGatewayName();
-		const apiId = await this._getApiIdAsync(apiName);
 		const mapping = await this._getMappingInfoV2Async(domainName, basePath);
 		if (mapping) {
 			return this.provider.request(AwsServices.ApiGatewayV2, "deleteApiMapping", {
-				ApiId: apiId,
 				ApiMappingId: mapping.ApiMappingId,
 				DomainName: domainName
 			});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-custom-domain",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-custom-domain",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Serverless plugin which creates a Custom Domain Name for the serverless service.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For the new APIGW mappings we don't need to provide the ApiId property in the `deleteApiMapping` request.